### PR TITLE
Add hjkl for window focus moving

### DIFF
--- a/binds.conf
+++ b/binds.conf
@@ -17,7 +17,7 @@ bind = $mainMod, C, exec, $hybrid       # launch hybrid text editor
 bind = $mainMod, F, exec, $browser      # launch web browser
 bind = $mainMod, E, exec, $files        # launch file manager
 
-bind = $mainMod, L, exec, hyprlock  # launch lock screen
+bind = $mainMod SHFIT, L, exec, hyprlock  # launch lock screen
 bind = Ctrl+Alt, W, exec, killall waybar || waybar  # toggle waybar
 
 # audio
@@ -44,6 +44,14 @@ bind = $mainMod, Down, movefocus, d
 
 bind = ALT, Tab, cyclenext,
 bind = ALT, Tab, bringactivetotop,
+
+
+# Move focus with mainMod and hjkl
+bind = $mainMod, H, movefocus, l
+bind = $mainMod, L, movefocus, r
+bind = $mainMod, K, movefocus, u
+bind = $mainMod, J, movefocus, d
+
 
 # move focused window to a workspace
 bind = $mainMod+Shift, 1, movetoworkspace, 1


### PR DESCRIPTION
- Added `hjkl` keybinds for window focus movement.  
- Changed lock screen binding to `Shift + L` to avoid conflict (`l` now moves focus to the left).

